### PR TITLE
update file name for planned outages from ReEDS

### DIFF
--- a/src/r2x/defaults/reeds_us_mapping.json
+++ b/src/r2x/defaults/reeds_us_mapping.json
@@ -303,7 +303,7 @@
       "value": "planned_outage_rate"
     },
     "description": "Planned outages per technology.",
-    "fname": "outage_planned.csv",
+    "fname": "planned_outage.csv",
     "input": true,
     "optional": true,
     "units": "%"


### PR DESCRIPTION
ReEDS has changed the name of the output file for outages from `outage_planned.csv` to `planned_outage.csv`; this PR adapts the name in the `reeds_us_mapping.json` file to handle this. 