### PR TITLE
fix(plexos_export): Added `coalduns` mapping to ReEDS and adding line flow exporter

### DIFF
--- a/src/r2x/defaults/plexos_reports.json
+++ b/src/r2x/defaults/plexos_reports.json
@@ -108,6 +108,30 @@
     "report_summary": true
   },
   {
+    "child_class": "Line",
+    "collection": "Lines",
+    "object_name": "base_report",
+    "parent_class": "System",
+    "phase_id": 4,
+    "property": "Flow",
+    "report_period": true,
+    "report_samples": false,
+    "report_statistics": false,
+    "report_summary": true
+  },
+  {
+    "child_class": "Line",
+    "collection": "Lines",
+    "object_name": "base_report",
+    "parent_class": "System",
+    "phase_id": 4,
+    "property": "Wheeling Cost",
+    "report_period": true,
+    "report_samples": false,
+    "report_statistics": false,
+    "report_summary": true
+  },
+  {
     "child_class": "Region",
     "collection": "Regions",
     "object_name": "base_report",

--- a/src/r2x/defaults/reeds_input.json
+++ b/src/r2x/defaults/reeds_input.json
@@ -93,6 +93,7 @@
     "coal-igcc": "ThermalStandard",
     "coal-new": "ThermalStandard",
     "coaloldscr": "ThermalStandard",
+    "coalolduns": "ThermalStandard",
     "coaluns": "ThermalStandard",
     "distpv": "RenewableNonDispatch",
     "egs_nearfield": "ThermalStandard",


### PR DESCRIPTION
fixing an error causing some coal capacity to be dropped, also adding line flow as a standard output