### PR TITLE
Add 'hydsnd' tech and set null on csp keys

### DIFF
--- a/src/r2x/defaults/reeds_input.json
+++ b/src/r2x/defaults/reeds_input.json
@@ -262,31 +262,31 @@
       "type": "ST"
     },
     "csp": {
-      "fuel": "SOLAR",
+      "fuel": null,
       "type": "CP"
     },
     "csp-ns": {
-      "fuel": "SOLAR",
+      "fuel": null,
       "type": "CP"
     },
     "csp1": {
-      "fuel": "SOLAR",
+      "fuel": null,
       "type": "CP"
     },
     "csp2": {
-      "fuel": "SOLAR",
+      "fuel": null,
       "type": "CP"
     },
     "csp3": {
-      "fuel": "SOLAR",
+      "fuel": null,
       "type": "CP"
     },
     "csp4": {
-      "fuel": "SOLAR",
+      "fuel": null,
       "type": "CP"
     },
     "csp5": {
-      "fuel": "SOLAR",
+      "fuel": null,
       "type": "CP"
     },
     "default": {
@@ -366,6 +366,10 @@
       "type": "HY"
     },
     "hydund": {
+      "fuel": null,
+      "type": "HY"
+    },
+    "hydsnd": {
       "fuel": null,
       "type": "HY"
     },

--- a/src/r2x/defaults/reeds_input.json
+++ b/src/r2x/defaults/reeds_input.json
@@ -361,15 +361,15 @@
       "fuel": null,
       "type": "HY"
     },
+    "hydsnd": {
+      "fuel": null,
+      "type": "HY"
+    },
     "hydud": {
       "fuel": null,
       "type": "HY"
     },
     "hydund": {
-      "fuel": null,
-      "type": "HY"
-    },
-    "hydsnd": {
       "fuel": null,
       "type": "HY"
     },


### PR DESCRIPTION
- Adding new key from reeds:
"hydsnd": {
      "fuel": null,
      "type": "HY"
    },
- Setting "csp" fuel keys to null for type "CP", i.e.:
"csp2": {
      "fuel": null,
      "type": "CP"
    },

Solving issue #120 