### PR TITLE
fix: hmap_myr.csv and can_imports_quarter_frac.csv for ReEDS compatibility

### DIFF
--- a/src/r2x/defaults/reeds_us_mapping.json
+++ b/src/r2x/defaults/reeds_us_mapping.json
@@ -30,7 +30,7 @@
       "frac": "value"
     },
     "description": "fraction of annual imports that occur in each season",
-    "fname": "can_imports_szn_frac.csv",
+    "fname": "can_imports_quarter_frac.csv",
     "input": true,
     "optional": true,
     "units": "-"

--- a/src/r2x/defaults/reeds_us_mapping.json
+++ b/src/r2x/defaults/reeds_us_mapping.json
@@ -26,7 +26,7 @@
   },
   "canada_szn_frac": {
     "column_mapping": {
-      "*szn": "season",
+      "*quarter": "season",
       "frac": "value"
     },
     "description": "fraction of annual imports that occur in each season",

--- a/src/r2x/upgrader/file_tracker.csv
+++ b/src/r2x/upgrader/file_tracker.csv
@@ -19,3 +19,4 @@ outage_planned.csv,planned_outage.csv,,,,rename,
 recf.h5,,,,,convert_hdf,
 load.h5,,,,,convert_hdf,
 co2_cap.csv,,,,,apply_header,"{'header': '*t,tonne_per_year'}"
+hmap_myr.csv,,,,inputs_case/rep/hmap_myr.csv,move_file,

--- a/src/r2x/upgrader/file_tracker.csv
+++ b/src/r2x/upgrader/file_tracker.csv
@@ -2,7 +2,7 @@
 minhyd.csv,hydro_mingen.csv,,,,"melt,rename",
 reeds_ba_tz_map.csv,reeds_region_tz_map.csv,,,,rename,
 hydcfadj.csv,hydcapadj.csv,,,,rename,
-can_imports_szn_frac.csv,,"*szn,frac",,,apply_header,
+can_imports_szn_frac.csv,can_imports_quarter_frac.csv,"*quarter,frac",,,"apply_header,move_file",
 can_imports.csv,,,r,,"set_index,melt","{'melt_id_vars':['r'], 'var_name': 't'}"
 storage_duration.csv,,"i,value",,outputs/storage_duration.csv,"apply_header,move_file",
 storage_eff.csv,,,,outputs/storage_eff.csv,move_file,

--- a/src/r2x/upgrader/file_tracker.csv
+++ b/src/r2x/upgrader/file_tracker.csv
@@ -2,7 +2,7 @@
 minhyd.csv,hydro_mingen.csv,,,,"melt,rename",
 reeds_ba_tz_map.csv,reeds_region_tz_map.csv,,,,rename,
 hydcfadj.csv,hydcapadj.csv,,,,rename,
-can_imports_szn_frac.csv,can_imports_quarter_frac.csv,"*quarter,frac",,,"apply_header,move_file",
+can_imports_szn_frac.csv,can_imports_quarter_frac.csv,"*szn,frac",,,"apply_header,move_file","{'header': '*quarter,frac'}"
 can_imports.csv,,,r,,"set_index,melt","{'melt_id_vars':['r'], 'var_name': 't'}"
 storage_duration.csv,,"i,value",,outputs/storage_duration.csv,"apply_header,move_file",
 storage_eff.csv,,,,outputs/storage_eff.csv,move_file,

--- a/src/r2x/upgrader/file_tracker.csv
+++ b/src/r2x/upgrader/file_tracker.csv
@@ -2,7 +2,7 @@
 minhyd.csv,hydro_mingen.csv,,,,"melt,rename",
 reeds_ba_tz_map.csv,reeds_region_tz_map.csv,,,,rename,
 hydcfadj.csv,hydcapadj.csv,,,,rename,
-can_imports_szn_frac.csv,can_imports_quarter_frac.csv,"*szn,frac",,,"apply_header,move_file","{'header': '*quarter,frac'}"
+can_imports_szn_frac.csv,can_imports_quarter_frac.csv,"*quarter,frac",,,"apply_header,move_file","{'header': '*quarter,frac'}"
 can_imports.csv,,,r,,"set_index,melt","{'melt_id_vars':['r'], 'var_name': 't'}"
 storage_duration.csv,,"i,value",,outputs/storage_duration.csv,"apply_header,move_file",
 storage_eff.csv,,,,outputs/storage_eff.csv,move_file,

--- a/src/r2x/upgrader/functions.py
+++ b/src/r2x/upgrader/functions.py
@@ -130,6 +130,8 @@ def move_file(fpath: pathlib.Path, new_fpath: str | pathlib.Path) -> pathlib.Pat
     if not isinstance(new_fpath, pathlib.Path):
         new_fpath = fpath.parent.parent / new_fpath
 
+    os.makedirs(os.path.dirname(new_fpath), exist_ok=True)
+
     if os.path.exists(new_fpath):
         logger.debug(f"File {fpath.name} already exists in the right place.")
         return None

--- a/src/r2x/utils.py
+++ b/src/r2x/utils.py
@@ -38,6 +38,7 @@ DEFAULT_SEARCH_FOLDERS = [
     "inputs_case",
     "outputs_perturb",
     "inputs_case/supplycurve_metadata",
+    "inputs_case/rep",
     ".",
 ]
 


### PR DESCRIPTION
This PR makes a few tweaks to filepaths and names for compatibility with https://github.nrel.gov/ReEDS/ReEDS-2.0/pull/1579. I tested locally and it works for a case run on that branch.