### PR TITLE
Modifying switches.csv parsing for ReEDS

### DIFF
--- a/tests/test_plugin_emission_cap.py
+++ b/tests/test_plugin_emission_cap.py
@@ -139,11 +139,12 @@ def test_update_system_using_cli(test_system):
 def test_emission_source(test_system, caplog):
     config, system, parser = test_system
 
-    # Manually adding the switch
-    # NOTE: We might need to modify this if we change the parsing of this file
-    # https://github.com/NREL/R2X/issues/177
-    adding_precombustion_switch = polars.DataFrame([{"aws": "gsw_precombustion", "0": "true"}])
-    parser.data["switches"] = polars.concat([parser.data["switches"], adding_precombustion_switch])
+    parser.data["switches"] = parser.data["switches"].with_columns(
+        polars.when(polars.col("aws") == "gsw_precombustion")
+        .then(polars.lit("true"))  # change "gsw_precombustion" to true
+        .otherwise(polars.col("0"))
+        .alias("0")
+    )
     # Adding precombustion to the first generator
     adding_precombustion_entry = polars.DataFrame(
         [


### PR DESCRIPTION
In runner.py it is check if config is a ReEDS instance to add the missing gsw_precombustion column and set it to its default "false", so that it appears on the switches dict and avoid manually changing in the tests.

The change in test_plugin_emission_cap is for setting the new column as "true" to handle the other possible scenario when the emission source precombustion is added.