### PR TITLE
Add new tech to tech_to_fuel_pm reeds input mapping

### DIFF
--- a/src/r2x/defaults/reeds_input.json
+++ b/src/r2x/defaults/reeds_input.json
@@ -249,6 +249,10 @@
       "fuel": "COAL",
       "type": "ST"
     },
+    "coal-igcc_coal-ccs_mod": {
+      "fuel": "COAL",
+      "type": "ST"
+    },
     "coal-new": {
       "fuel": "COAL",
       "type": "ST"
@@ -258,6 +262,14 @@
       "type": "ST"
     },
     "coaloldscr": {
+      "fuel": "COAL",
+      "type": "ST"
+    },
+    "coaloldscr-igcc_coal-ccs_mod": {
+      "fuel": "COAL",
+      "type": "ST"
+    },
+    "coaloldscr_coal-ccs_mod": {
       "fuel": "COAL",
       "type": "ST"
     },
@@ -393,6 +405,10 @@
       "fuel": "NUCLEAR",
       "type": "ST"
     },
+    "nuclear-smr": {
+      "fuel": "NUCLEAR",
+      "type": "ST"
+    },
     "o-g-s": {
       "fuel": "OTHER",
       "type": "GT"
@@ -404,6 +420,14 @@
     "pvb": {
       "fuel": null,
       "type": "PVe"
+    },
+    "smr": {
+      "fuel": "NUCLEAR",
+      "type": "ST"
+    },
+    "smr_css": {
+      "fuel": "NUCLEAR",
+      "type": "ST"
     },
     "undisc": {
       "fuel": "GEOTHERMAL",


### PR DESCRIPTION
New keys added:
- coal-igcc_coal-ccs_mod
- coaloldscr-igcc_coal-ccs_mod
- coaloldscr_coal-ccs_mod
- nuclear-smr
- smr
- smr_css