### PR TITLE
V2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "ruff~=0.9",
     "types-pyyaml>=6.0.12.20240917",
     "bump2version>=1.0.1",
+    "pytest-xdist>=3.6.1",
 ]
 docs = [
     "autodoc-pydantic>=2.2.0",

--- a/src/r2x/plugin_manager/plugin_manager.py
+++ b/src/r2x/plugin_manager/plugin_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import inspect
+from pathlib import Path
 import importlib
 import importlib.metadata
 from typing import ParamSpec, TYPE_CHECKING, ClassVar
@@ -18,8 +19,6 @@ if TYPE_CHECKING:
     from r2x.exporter.handler import BaseExporter
     from r2x.config_models import BaseModelConfig
 
-
-DEFAULT_SYSMOD_PATH = "src/r2x/plugins"
 
 
 class PluginManager:
@@ -133,7 +132,9 @@ class PluginManager:
         _ = (pl_rename, pl_filter_by_year)
 
         # Internal System Modifiers
-        register_functions_from_folder(DEFAULT_SYSMOD_PATH)
+        script_dir = Path(__file__).parent.parent
+        plugins_path = script_dir / "plugins"
+        register_functions_from_folder(plugins_path)
 
         # External plugins (factories via entry points)
         for entry_point in importlib.metadata.entry_points().select(group="r2x_plugin"):

--- a/src/r2x/plugin_manager/plugin_manager.py
+++ b/src/r2x/plugin_manager/plugin_manager.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from r2x.config_models import BaseModelConfig
 
 
-
 class PluginManager:
     """
     Centralized manager for R2X plugins.

--- a/src/r2x/plugin_manager/utils.py
+++ b/src/r2x/plugin_manager/utils.py
@@ -25,12 +25,12 @@ def register_functions_from_folder(folder_path: str | Path):
 
     # Loop through files in the folder
     for filename in folder_path.glob("*.py"):  # Use glob to safely get .py files
-            if filename.name != "__init__.py":  # Skip __init__.py
-                module_name = f"r2x.plugins.{filename.stem}"  # e.g., r2x.plugins.break_gens
-                try:
-                    _ = importlib.import_module(module_name)
-                    logger.debug(f"Successfully imported and registered functions from {module_name}")
-                except ImportError as e:
-                    logger.error(f"Error importing {module_name}: {e!s}")
-                except Exception as e:
-                    logger.error(f"Unexpected error with {module_name}: {e!s}")
+        if filename.name != "__init__.py":  # Skip __init__.py
+            module_name = f"r2x.plugins.{filename.stem}"  # e.g., r2x.plugins.break_gens
+            try:
+                _ = importlib.import_module(module_name)
+                logger.debug(f"Successfully imported and registered functions from {module_name}")
+            except ImportError as e:
+                logger.error(f"Error importing {module_name}: {e!s}")
+            except Exception as e:
+                logger.error(f"Unexpected error with {module_name}: {e!s}")

--- a/src/r2x/plugin_manager/utils.py
+++ b/src/r2x/plugin_manager/utils.py
@@ -20,21 +20,17 @@ def register_functions_from_folder(folder_path: str | Path):
     folder_path = Path(folder_path)
     # Ensure folder path exists
     if not os.path.exists(folder_path):
-        raise FileNotFoundError(f"Folder not found: {folder_path}")
+        msg = f"Folder not found: {folder_path}"
+        raise FileNotFoundError(msg)
 
     # Loop through files in the folder
-    for filename in os.listdir(folder_path):
-        # Check if file is a Python file (ends with .py) and not __init__.py
-        if filename.endswith(".py") and filename != "__init__.py":
-            # Remove .py extension to get module name
-            module_name = str(folder_path).replace("src/", "").replace("/", ".") + "." + filename[:-3]
-
-            try:
-                # Dynamically import the module. Functions will be registered automatically
-                _ = importlib.import_module(module_name)
-                # logger.debug(f"Successfully registered {module.__name__}")
-
-            except ImportError as e:
-                logger.error(f"Error importing {module_name}: {e!s}")
-            except Exception as e:
-                logger.error(f"Unexpected error with {module_name}: {e!s}")
+    for filename in folder_path.glob("*.py"):  # Use glob to safely get .py files
+            if filename.name != "__init__.py":  # Skip __init__.py
+                module_name = f"r2x.plugins.{filename.stem}"  # e.g., r2x.plugins.break_gens
+                try:
+                    _ = importlib.import_module(module_name)
+                    logger.debug(f"Successfully imported and registered functions from {module_name}")
+                except ImportError as e:
+                    logger.error(f"Error importing {module_name}: {e!s}")
+                except Exception as e:
+                    logger.error(f"Unexpected error with {module_name}: {e!s}")


### PR DESCRIPTION
- Fixed the plugin_manager to use a the current script path and relative navigation to load the sysmods in the /plugins directory.
- Added pytest-xdist to the dev dependencies so you can run tests in parallel with `pytest -n auto`